### PR TITLE
CV content updates, env-based secrets, LinkedIn

### DIFF
--- a/.github/workflows/build-cv.yml
+++ b/.github/workflows/build-cv.yml
@@ -37,7 +37,12 @@ jobs:
         run: docker build -t cv-builder .
 
       - name: Generate CV artifacts
-        run: docker run --rm -v ${{ github.workspace }}/dist:/app/dist cv-builder --all
+        run: |
+          docker run --rm \
+            -e CV_EMAIL="${{ secrets.CV_EMAIL }}" \
+            -e CV_PHONE="${{ secrets.CV_PHONE }}" \
+            -v ${{ github.workspace }}/dist:/app/dist \
+            cv-builder --all
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,9 @@
 IMAGE := cv-builder
+DOCKER_RUN := docker run --rm \
+	-e CV_EMAIL \
+	-e CV_PHONE \
+	-v $(CURDIR)/dist:/app/dist \
+	$(IMAGE)
 
 .PHONY: all build clean serve help html pdf docx docker-build
 
@@ -15,21 +20,24 @@ help:
 	@echo "  serve        - Build and serve dist/ locally on port 8000"
 	@echo "  clean        - Remove dist/ and build artifacts"
 	@echo "  docker-build - Build the Docker image"
+	@echo ""
+	@echo "Set CV_EMAIL and CV_PHONE env vars for PDF/DOCX contact info:"
+	@echo "  CV_EMAIL=you@example.com CV_PHONE='+44...' make build"
 
 docker-build:
 	docker build -t $(IMAGE) .
 
 build: docker-build
-	docker run --rm -v $(CURDIR)/dist:/app/dist $(IMAGE) --all
+	$(DOCKER_RUN) --all
 
 html: docker-build
-	docker run --rm -v $(CURDIR)/dist:/app/dist $(IMAGE) --html
+	$(DOCKER_RUN) --html
 
 pdf: docker-build
-	docker run --rm -v $(CURDIR)/dist:/app/dist $(IMAGE) --pdf
+	$(DOCKER_RUN) --pdf
 
 docx: docker-build
-	docker run --rm -v $(CURDIR)/dist:/app/dist $(IMAGE) --docx
+	$(DOCKER_RUN) --docx
 
 serve: build
 	python -m http.server --directory dist 8000

--- a/README.md
+++ b/README.md
@@ -1,20 +1,21 @@
 # CV Publishing System
 
-Markdown-as-source-of-truth CV pipeline. Edit `cv/cv.md`, run one build command, get HTML, PDF, and DOCX.
+[![Build & Deploy CV](https://github.com/lucaromagnoli/resume/actions/workflows/build-cv.yml/badge.svg)](https://github.com/lucaromagnoli/resume/actions/workflows/build-cv.yml)
+[![GitHub Pages](https://img.shields.io/badge/live-lucaromagnoli.dev-blue)](https://lucaromagnoli.dev)
+[![License](https://img.shields.io/github/license/lucaromagnoli/resume)](LICENSE)
+
+Markdown-as-source-of-truth CV pipeline. Edit `cv/cv.md`, run one command, get HTML + PDF + DOCX.
 
 ## Quick start
 
+Everything runs in Docker -- no local Pandoc or LaTeX install needed.
+
 ```bash
-# Install dependencies
-pip install -e .
-
-# Install system tools (required for PDF)
-# macOS: brew install pandoc basictex
-# Linux: apt install pandoc texlive-xetex
-
 # Build all outputs
 make build
-# or: python cv/build.py --all
+
+# With contact info for PDF/DOCX
+CV_EMAIL="you@example.com" CV_PHONE="+44..." make build
 
 # Preview locally
 make serve
@@ -25,39 +26,53 @@ make serve
 
 | Output | Path | Purpose |
 |--------|------|---------|
-| HTML | `dist/index.html` | Public hosted page |
-| PDF | `dist/cv.pdf` | Recruiter download |
+| HTML | `dist/index.html` | Public page with dark/light theme |
+| PDF | `dist/cv.pdf` | Recruiter download (Inter font) |
 | DOCX | `dist/cv.docx` | Editable export |
 
-The HTML page includes Download PDF and Download DOCX buttons.
+The HTML page includes download buttons and a theme toggle. Email and phone are excluded from the public HTML page.
 
 ## Project structure
 
 ```
 cv/
-  cv.md          # Source of truth
-  build.py       # Build script
+  cv.md              # Source of truth
+  build.py           # Build script
+  CNAME              # Custom domain for GitHub Pages
   templates/
-    cv.html.j2   # HTML layout
-    cv.tex       # LaTeX template for PDF
+    cv.html.j2       # Tailwind HTML layout
+    cv.tex           # LaTeX template (Inter, titlesec)
   styles/
     cv.css
-  assets/        # Optional: avatar, icons
-dist/            # Generated outputs (gitignored)
+Dockerfile           # Pandoc + TeX Live + Inter font
+Makefile             # Docker-based build targets
+.github/workflows/
+  build-cv.yml       # CI: lint, build, deploy to GitHub Pages
+.pre-commit-config.yaml  # ruff, uv-lock, rust fmt/clippy
+dist/                # Generated outputs (gitignored)
 ```
 
-## Build options
+## Make targets
 
-```bash
-python cv/build.py           # All outputs (default)
-python cv/build.py --html    # HTML only
-python cv/build.py --pdf     # PDF only
-python cv/build.py --docx    # DOCX only
+```
+make build        # Generate all outputs (HTML, PDF, DOCX)
+make html         # HTML only
+make pdf          # PDF only
+make docx         # DOCX only
+make serve        # Build and serve on port 8000
+make clean        # Remove dist/
+make docker-build # Build the Docker image only
 ```
 
-## Deployment
+## CI/CD
 
-Deploy `dist/` to any static host: GitHub Pages, Cloudflare Pages, Netlify, Vercel. Ensure `index.html`, `cv.pdf`, `cv.docx`, and `cv.css` are published.
+GitHub Actions pipeline on push to `main`:
+
+1. **Lint** -- pre-commit checks (ruff, trailing whitespace, yaml, etc.)
+2. **Build** -- Docker build, generate artifacts with secrets injected
+3. **Deploy** -- publish to GitHub Pages at [lucaromagnoli.dev](https://lucaromagnoli.dev)
+
+Contact info (`CV_EMAIL`, `CV_PHONE`) is stored as GitHub secrets and injected at build time.
 
 ## Spec
 

--- a/cv/build.py
+++ b/cv/build.py
@@ -9,6 +9,8 @@ Requires: Python 3.x, Pandoc, TeX (xelatex).
 from __future__ import annotations
 
 import argparse
+import os
+import re
 import shutil
 import subprocess
 from pathlib import Path
@@ -64,6 +66,20 @@ def check_latex() -> None:
 PRIVATE_PATTERNS = ["Email:", "Phone:"]
 
 
+def _resolve_env_vars(md_text: str) -> str:
+    """Replace ${VAR} placeholders with environment variable values."""
+
+    def _replace(match: re.Match) -> str:
+        return os.environ.get(match.group(1), match.group(0))
+
+    return re.sub(r"\$\{(\w+)}", _replace, md_text)
+
+
+def _read_md(md_path: Path) -> str:
+    """Read markdown and resolve env var placeholders."""
+    return _resolve_env_vars(md_path.read_text(encoding="utf-8"))
+
+
 def _strip_private_lines(md_text: str) -> str:
     """Remove lines containing private contact info for the public HTML build."""
     return "\n".join(
@@ -73,9 +89,8 @@ def _strip_private_lines(md_text: str) -> str:
     )
 
 
-def md_to_html_body(md_path: Path) -> str:
-    """Convert Markdown to HTML fragment (body only, no document wrapper)."""
-    md_text = _strip_private_lines(md_path.read_text(encoding="utf-8"))
+def md_to_html_body(md_text: str) -> str:
+    """Convert Markdown string to HTML fragment (body only, no document wrapper)."""
     result = subprocess.run(
         [
             "pandoc",
@@ -93,7 +108,17 @@ def md_to_html_body(md_path: Path) -> str:
     return result.stdout
 
 
-def build_html(md_path: Path) -> None:
+def _run_pandoc_stdin(md_text: str, args: list[str]) -> None:
+    """Run pandoc with markdown fed via stdin."""
+    cmd = ["pandoc", "-f", "markdown", *args]
+    result = subprocess.run(cmd, input=md_text, capture_output=True, text=True)
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"Command failed: {' '.join(cmd)}\n{result.stderr or result.stdout}"
+        )
+
+
+def build_html(md_text: str) -> None:
     try:
         from jinja2 import Environment, FileSystemLoader
     except ImportError:
@@ -101,7 +126,8 @@ def build_html(md_path: Path) -> None:
             "Jinja2 is required for HTML generation. Install: pip install jinja2"
         )
 
-    body_html = md_to_html_body(md_path)
+    public_md = _strip_private_lines(md_text)
+    body_html = md_to_html_body(public_md)
     env = Environment(loader=FileSystemLoader(str(TEMPLATES_DIR)))
     template = env.get_template("cv.html.j2")
     html = template.render(body=body_html)
@@ -112,7 +138,7 @@ def build_html(md_path: Path) -> None:
     print(f"Generated {out_path}")
 
 
-def build_pdf(md_path: Path) -> None:
+def build_pdf(md_text: str) -> None:
     tex_template = TEMPLATES_DIR / "cv.tex"
     if not tex_template.exists():
         raise FileNotFoundError(f"LaTeX template not found: {tex_template}")
@@ -120,33 +146,23 @@ def build_pdf(md_path: Path) -> None:
     DIST_DIR.mkdir(parents=True, exist_ok=True)
     out_path = DIST_DIR / "cv.pdf"
 
-    cmd = [
-        "pandoc",
-        str(md_path),
-        "-f",
-        "markdown",
-        "-o",
-        str(out_path),
-        f"--template={tex_template}",
-        "--pdf-engine=xelatex",
-    ]
-    _run(cmd)
+    _run_pandoc_stdin(
+        md_text,
+        [
+            "-o",
+            str(out_path),
+            f"--template={tex_template}",
+            "--pdf-engine=xelatex",
+        ],
+    )
     print(f"Generated {out_path}")
 
 
-def build_docx(md_path: Path) -> None:
+def build_docx(md_text: str) -> None:
     DIST_DIR.mkdir(parents=True, exist_ok=True)
     out_path = DIST_DIR / "cv.docx"
 
-    cmd = [
-        "pandoc",
-        str(md_path),
-        "-f",
-        "markdown",
-        "-o",
-        str(out_path),
-    ]
-    _run(cmd)
+    _run_pandoc_stdin(md_text, ["-o", str(out_path)])
     print(f"Generated {out_path}")
 
 
@@ -219,23 +235,25 @@ def main() -> None:
     if not CV_MD.exists():
         raise SystemExit(f"Source file not found: {CV_MD}")
 
+    md_text = _read_md(CV_MD)
+
     if do_all:
-        build_html(CV_MD)
-        build_pdf(CV_MD)
-        build_docx(CV_MD)
+        build_html(md_text)
+        build_pdf(md_text)
+        build_docx(md_text)
         copy_styles()
         copy_assets()
         copy_cname()
     else:
         if args.html:
-            build_html(CV_MD)
+            build_html(md_text)
             copy_styles()
             copy_assets()
             copy_cname()
         if args.pdf:
-            build_pdf(CV_MD)
+            build_pdf(md_text)
         if args.docx:
-            build_docx(CV_MD)
+            build_docx(md_text)
 
 
 if __name__ == "__main__":

--- a/cv/build.py
+++ b/cv/build.py
@@ -61,18 +61,31 @@ def check_latex() -> None:
     )
 
 
+PRIVATE_PATTERNS = ["Email:", "Phone:"]
+
+
+def _strip_private_lines(md_text: str) -> str:
+    """Remove lines containing private contact info for the public HTML build."""
+    return "\n".join(
+        line
+        for line in md_text.splitlines()
+        if not any(p in line for p in PRIVATE_PATTERNS)
+    )
+
+
 def md_to_html_body(md_path: Path) -> str:
     """Convert Markdown to HTML fragment (body only, no document wrapper)."""
+    md_text = _strip_private_lines(md_path.read_text(encoding="utf-8"))
     result = subprocess.run(
         [
             "pandoc",
-            str(md_path),
             "-f",
             "markdown",
             "-t",
             "html",
             "--wrap=none",
         ],
+        input=md_text,
         capture_output=True,
         text=True,
         check=True,

--- a/cv/cv.md
+++ b/cv/cv.md
@@ -8,6 +8,7 @@ Senior Software Engineer -- AI Systems, Distributed Backend, LLM Infrastructure
 - Email: romagnoli.luca@gmail.com
 - Phone: +44 (0)75 0362 7335
 - GitHub: [github.com/lucaromagnoli](https://github.com/lucaromagnoli)
+- LinkedIn: [linkedin.com/in/lucaromagnoli79](https://www.linkedin.com/in/lucaromagnoli79/)
 
 ## Summary
 

--- a/cv/cv.md
+++ b/cv/cv.md
@@ -127,14 +127,17 @@ AI-driven system translating natural language into DAW commands using a multi-ag
 ### grammar-school
 
 A multi-language framework for building tiny, LLM-friendly domain-specific languages (DSLs).
+[github.com/Conceptual-Machines/grammar-school](https://github.com/Conceptual-Machines/grammar-school)
 
 ### grammar-school-python
 
 Python implementation and support for Grammar School DSL concepts.
+[github.com/Conceptual-Machines/grammar-school-python](https://github.com/Conceptual-Machines/grammar-school-python)
 
 ### grammar-school-go
 
 Go implementation and support for Grammar School DSLs.
+[github.com/Conceptual-Machines/grammar-school-go](https://github.com/Conceptual-Machines/grammar-school-go)
 
 ### DataService -- Scalable data gathering library for Python
 

--- a/cv/cv.md
+++ b/cv/cv.md
@@ -145,5 +145,7 @@ Go implementation and support for Grammar School DSLs.
 
 ## Education
 
-**Open University** -- Final Year Project
-Machine-learning fashion search engine using TensorFlow and Annoy.
+**BSc Computer Science** -- Open University
+
+Final Year Project: Machine-learning fashion search engine using TensorFlow and Annoy.
+[github.com/lucaromagnoli/open-uni-final-project](https://github.com/lucaromagnoli/open-uni-final-project)

--- a/cv/cv.md
+++ b/cv/cv.md
@@ -5,8 +5,8 @@ Senior Software Engineer -- AI Systems, Distributed Backend, LLM Infrastructure
 ## Contact
 
 - Location: London, UK
-- Email: romagnoli.luca@gmail.com
-- Phone: +44 (0)75 0362 7335
+- Email: ${CV_EMAIL}
+- Phone: ${CV_PHONE}
 - GitHub: [github.com/lucaromagnoli](https://github.com/lucaromagnoli)
 - LinkedIn: [linkedin.com/in/lucaromagnoli79](https://www.linkedin.com/in/lucaromagnoli79/)
 


### PR DESCRIPTION
## Summary

- **Privacy**: email and phone injected from env vars (`CV_EMAIL`, `CV_PHONE`) via GitHub secrets — no longer checked into source. HTML strips them entirely for the public page.
- **Content**: added grammar-school project links, BSc education with project link, LinkedIn profile
- **CI**: secrets passed to Docker build in GitHub Actions

## Test plan

- [ ] `CV_EMAIL=x CV_PHONE=y make build` — PDF/DOCX contain email/phone, HTML does not
- [ ] Build without env vars — placeholders remain in PDF/DOCX, HTML unaffected
- [ ] CI build passes with secrets set

Co-authored-by: CM Claude