### PR TITLE
Rename CV outputs to Luca_Romagnoli_resume_YYYY-MM-DD

### DIFF
--- a/cv/build.py
+++ b/cv/build.py
@@ -13,6 +13,7 @@ import os
 import re
 import shutil
 import subprocess
+from datetime import date
 from pathlib import Path
 
 # Paths
@@ -130,7 +131,12 @@ def build_html(md_text: str) -> None:
     body_html = md_to_html_body(public_md)
     env = Environment(loader=FileSystemLoader(str(TEMPLATES_DIR)))
     template = env.get_template("cv.html.j2")
-    html = template.render(body=body_html)
+    today = date.today()
+    html = template.render(
+        body=body_html,
+        pdf_file=f"Luca_Romagnoli_resume_{today}.pdf",
+        docx_file=f"Luca_Romagnoli_resume_{today}.docx",
+    )
 
     DIST_DIR.mkdir(parents=True, exist_ok=True)
     out_path = DIST_DIR / "index.html"
@@ -144,7 +150,7 @@ def build_pdf(md_text: str) -> None:
         raise FileNotFoundError(f"LaTeX template not found: {tex_template}")
 
     DIST_DIR.mkdir(parents=True, exist_ok=True)
-    out_path = DIST_DIR / "cv.pdf"
+    out_path = DIST_DIR / f"Luca_Romagnoli_resume_{date.today()}.pdf"
 
     _run_pandoc_stdin(
         md_text,
@@ -160,7 +166,7 @@ def build_pdf(md_text: str) -> None:
 
 def build_docx(md_text: str) -> None:
     DIST_DIR.mkdir(parents=True, exist_ok=True)
-    out_path = DIST_DIR / "cv.docx"
+    out_path = DIST_DIR / f"Luca_Romagnoli_resume_{date.today()}.docx"
 
     _run_pandoc_stdin(md_text, ["-o", str(out_path)])
     print(f"Generated {out_path}")

--- a/cv/cv.md
+++ b/cv/cv.md
@@ -150,3 +150,9 @@ Go implementation and support for Grammar School DSLs.
 
 Final Year Project: Machine-learning fashion search engine using TensorFlow and Annoy.
 [github.com/lucaromagnoli/open-uni-final-project](https://github.com/lucaromagnoli/open-uni-final-project)
+
+## Interests
+
+### Electronic Music Production
+
+Producing electronic music and building tools to bridge AI and digital audio workstations.

--- a/cv/templates/cv.html.j2
+++ b/cv/templates/cv.html.j2
@@ -141,12 +141,12 @@
             <span class="text-sm font-semibold text-slate-700 dark:text-slate-300 tracking-tight">Luca Romagnoli</span>
             <div class="flex items-center gap-3">
                 <nav class="flex gap-2">
-                    <a href="cv.pdf" download
+                    <a href="{{ pdf_file }}" download
                        class="inline-flex items-center gap-1.5 px-4 py-1.5 text-sm font-medium text-white bg-indigo-600 rounded-lg hover:bg-indigo-700 transition shadow-sm">
                         <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 10v6m0 0l-3-3m3 3l3-3m2 8H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"/></svg>
                         PDF
                     </a>
-                    <a href="cv.docx" download
+                    <a href="{{ docx_file }}" download
                        class="inline-flex items-center gap-1.5 px-4 py-1.5 text-sm font-medium text-slate-700 dark:text-slate-300 bg-white dark:bg-slate-800 border border-slate-300 dark:border-slate-600 rounded-lg hover:bg-slate-50 dark:hover:bg-slate-700 transition shadow-sm">
                         <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 10v6m0 0l-3-3m3 3l3-3m2 8H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"/></svg>
                         DOCX


### PR DESCRIPTION
## Summary

- Rename PDF/DOCX output files from `cv.pdf`/`cv.docx` to `Luca_Romagnoli_resume_2026-03-13.pdf`/`.docx`
- HTML download links updated dynamically to match

## Test plan

- [ ] `make build` produces `dist/Luca_Romagnoli_resume_<today>.pdf` and `.docx`
- [ ] HTML download buttons link to the correct filenames

Co-authored-by: CM Claude